### PR TITLE
fix: Git i18n Match Issue

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -34,7 +34,8 @@ local function setup(_, options)
   }
 
   function Header:get_status()
-    local handle = io.popen("git status --ignore-submodules=dirty --branch --show-stash --ahead-behind 2>/dev/null")
+    --            Instead of LANGUAGE, you can try LANG, LC_ALL. If the plugin does not show up.
+    local handle = io.popen("LANGUAGE=en_US.UTF-8 git status --ignore-submodules=dirty --branch --show-stash --ahead-behind 2>/dev/null")
     local status = handle:read("*a")
     handle:close()
 

--- a/init.lua
+++ b/init.lua
@@ -34,7 +34,7 @@ local function setup(_, options)
   }
 
   function Header:get_status()
-    --            Instead of LANGUAGE, you can try LANG, LC_ALL. If the plugin does not show up.
+    -- Instead of LANGUAGE, you can try LANG, LC_ALL. If the plugin does not show up.
     local handle = io.popen("LANGUAGE=en_US.UTF-8 git status --ignore-submodules=dirty --branch --show-stash --ahead-behind 2>/dev/null")
     local status = handle:read("*a")
     handle:close()


### PR DESCRIPTION
issue: Git i18n changes the output text of the commands to different  languages. Thus, matching the text wouldn't work on that device. fix: Using some keywords this can be solved by converting the Git  output to English.
see:
- https://askubuntu.com/a/320663