### PR TITLE
fix: Overriding Default Config

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -195,11 +195,8 @@ local function setup(_, options)
       untracked,
     }
   end
-
-  Header._left = {
-    { Header.cwd,     id = 1, order = 1000 },
-    { Header.githead, id = 2, order = 2000 },
-  }
+  
+  Header:children_add(Header.githead, 1234, Header.LEFT)
 end
 
 return { setup = setup }

--- a/init.lua
+++ b/init.lua
@@ -196,7 +196,7 @@ local function setup(_, options)
     }
   end
   
-  Header:children_add(Header.githead, 1234, Header.LEFT)
+  Header:children_add(Header.githead, 2000, Header.LEFT)
 end
 
 return { setup = setup }


### PR DESCRIPTION
issue: Overriding default config might cause issues if different plugins overrides it at the same time.
fix: Using children_add function solves these issues.