### PR TITLE
feat: Yatline Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ Or manually copy `init.lua` to the `~/.config/yazi/plugins/githead.yazi/init.lua
 
 Add this to your `~/.config/yazi/init.lua`:
 
+> [!IMPORTANT]
+> If you are using yatline.yazi, put this after its initialization.
+
 ```lua
 require("githead"):setup()
 ```
@@ -62,6 +65,46 @@ require("githead"):setup({
   show_untracked = true,
   untracked_color = "blue",
   untracked_symbol = "?",
+})
+```
+
+You can also use a [theme](https://github.com/imsi32/yatline-themes):
+
+```lua
+local your_theme = {
+  branch_color = "blue",
+  commit_color = "bright magenta",
+  stashes_color = "bright magenta",
+  state_color = "red",
+  staged_color = "bright yellow",
+  unstaged_color = "bright yellow",
+  untracked_color = "blue",
+}
+
+require("githead"):setup({
+-- ===
+    
+  theme = your_theme,
+
+-- ===
+})
+```
+
+If you are using yatline.yazi, you can use these components:
+
+``` lua
+-- ===
+
+  {type = "coloreds", custom = false, name = "branch"},
+  {type = "coloreds", custom = false, name = "stashes"},
+  {type = "coloreds", custom = false, name = "state"},
+  {type = "coloreds", custom = false, name = "staged"},
+  {type = "coloreds", custom = false, name = "unstaged"},
+  {type = "coloreds", custom = false, name = "untracked"},
+
+  {type = "coloreds", custom = false, name = "githead"},
+
+-- ===
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Optionally, configure header:
 require("githead"):setup({
   show_branch = true,
   branch_prefix = "on",
+  prefix_color = "white"
   branch_color = "blue",
   branch_symbol = "",
   branch_borders = "()",
@@ -72,6 +73,7 @@ You can also use a [theme](https://github.com/imsi32/yatline-themes):
 
 ```lua
 local your_theme = {
+  prefix_color = "white"
   branch_color = "blue",
   commit_color = "bright magenta",
   stashes_color = "bright magenta",
@@ -90,17 +92,10 @@ require("githead"):setup({
 })
 ```
 
-If you are using yatline.yazi, you can use these components:
+If you are using yatline.yazi, you can use this component:
 
 ``` lua
 -- ===
-
-  {type = "coloreds", custom = false, name = "branch"},
-  {type = "coloreds", custom = false, name = "stashes"},
-  {type = "coloreds", custom = false, name = "state"},
-  {type = "coloreds", custom = false, name = "staged"},
-  {type = "coloreds", custom = false, name = "unstaged"},
-  {type = "coloreds", custom = false, name = "untracked"},
 
   {type = "coloreds", custom = false, name = "githead"},
 

--- a/init.lua
+++ b/init.lua
@@ -63,7 +63,7 @@ local function setup(_, options)
         local branch_prefix = config.branch_prefix == "" and " " or " " .. config.branch_prefix .. " "
         local commit_prefix = config.commit_symbol == "" and "" or config.commit_symbol
 
-        return { branch_prefix .. commit_prefix, commit }
+        return { "commit", branch_prefix .. commit_prefix, commit }
       end
     else
       local left_border = config.branch_borders:sub(1, 1)
@@ -79,7 +79,7 @@ local function setup(_, options)
 
       local branch_prefix = config.branch_prefix == "" and " " or " " .. config.branch_prefix .. " "
 
-      return { branch_prefix, branch_string }
+      return { "branch", branch_prefix, branch_string }
     end
   end
 
@@ -183,8 +183,8 @@ local function setup(_, options)
   function Header:githead()
     local status = get_status()
     local branch_array = get_branch(status)
-    local prefix = ui.Span(config.show_branch and branch_array[1] or ""):fg(theme.prefix_color)
-    local branch = ui.Span(config.show_branch and branch_array[2] or ""):fg(theme.branch_color)
+    local prefix = ui.Span(config.show_branch and branch_array[2] or ""):fg(theme.prefix_color)
+    local branch = ui.Span(config.show_branch and branch_array[3] or ""):fg(branch_array[1] == "commit" and theme.commit_color or theme.branch_color)
     local stashes = ui.Span(config.show_stashes and get_stashes(status) or ""):fg(theme.stashes_color)
     local state = ui.Span(config.show_state and get_state(status) or ""):fg(theme.state_color)
     local staged = ui.Span(config.show_staged and get_staged(status) or ""):fg(theme.staged_color)
@@ -203,8 +203,12 @@ local function setup(_, options)
 
       local branch = config.show_branch and get_branch(status) or ""
       if branch ~= nil and branch ~= "" then
-        table.insert(githead, { branch[1], theme.prefix_color })
-        table.insert(githead, { branch[2], theme.branch_color })
+        table.insert(githead, { branch[2], theme.prefix_color })
+	if branch[1] == "commit" then
+          table.insert(githead, { branch[3], theme.commit_color })
+	else
+          table.insert(githead, { branch[3], theme.branch_color })
+	end
       end
 
       local stashes = config.show_stashes and get_stashes(status) or ""


### PR DESCRIPTION
details: Yatline support implemented for githead. With these support new
coloreds types - branch, stashes, state, staged, unstaged, untracked and
githead - are now usable as components. Moreover, githead can use
yatline's theme system.

details: All the new features coming from yatline.yazi support is
described in README.md.